### PR TITLE
카프카 적용 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/example/hhpuls/concertReservation/application/repository/PaymentOutboxRepository.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/application/repository/PaymentOutboxRepository.java
@@ -1,0 +1,20 @@
+package com.example.hhpuls.concertReservation.application.repository;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentOutboxRepository {
+
+    public Optional<PaymentOutbox> findById(String id);
+
+    public PaymentOutbox save(PaymentOutbox paymentOutbox);
+
+    public void completeOutbox(String id);
+
+    public List<PaymentOutbox> findOutboxByStatusAndCreateDate(Integer status, LocalDateTime nowPlusFiveMin);
+
+    public List<PaymentOutbox> findOutBoxByStatus(Integer status);
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/application/service/PaymentService.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/application/service/PaymentService.java
@@ -2,21 +2,28 @@ package com.example.hhpuls.concertReservation.application.service;
 
 import com.example.hhpuls.concertReservation.application.command.PaymentCommand;
 import com.example.hhpuls.concertReservation.application.repository.*;
+import com.example.hhpuls.concertReservation.common.enums.PaymentOutboxStatus;
 import com.example.hhpuls.concertReservation.common.enums.PaymentStatus;
 import com.example.hhpuls.concertReservation.common.enums.SeatStatus;
 import com.example.hhpuls.concertReservation.common.exception.CustomException;
 import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentLog;
-import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEventPublisher;
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEventPublisher;
 import com.example.hhpuls.concertReservation.domain.domain.payment.message.PaymentMessageSender;
 import com.example.hhpuls.concertReservation.domain.domain.reservation.Reservation;
 import com.example.hhpuls.concertReservation.domain.domain.concert.Seat;
-import com.example.hhpuls.concertReservation.domain.domain.payment.UserPoint;
 import com.example.hhpuls.concertReservation.domain.domain.payment.Payment;
 import com.example.hhpuls.concertReservation.domain.error_code.ErrorCode;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
+import com.example.hhpuls.concertReservation.interfaces.event.publisher.PaymentOutboxEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Component
@@ -29,7 +36,8 @@ public class PaymentService {
     private final WaitingQueueService waitingQueueService;
     private final PaymentLogRepository paymentLogRepository;
     private final PaymentEventPublisher paymentEventPublisher;
-    private final PaymentMessageSender paymentMessageSender;
+    private final PaymentOutboxEventPublisher paymentOutboxEventPublisher;
+    private final PaymentOutboxRepository paymentOutboxRepository;
 
     public Payment create(Long reservationId, Integer price, Long userId) {
         Payment payment = new Payment(null, reservationId, price, PaymentStatus.WAITING.getValue());
@@ -63,20 +71,34 @@ public class PaymentService {
         // 좌석 예약완료상태로 업데이트
         findSeat.updateSeatStatus(SeatStatus.CONFIRM.getValue());
 
-        // 유저 포인트 차감
-        this.paymentMessageSender.send(new PaymentEvent(command.userId(), findPayment.getId(), findPayment.getPaymentPrice()));
-
         // 결제내역 결제완료 상태로 업데이트
         findPayment.done();
         // 예약 예약완료 상태로 업데이트
         reservation.done();
 
+        String paymentOutBoxId = UUID.randomUUID().toString();
+        this.paymentOutboxEventPublisher.publish(new PaymentOutbox(paymentOutBoxId, findPayment.getId(), PaymentOutboxStatus.INIT.getValue(), command.userId(), command.point()));
+
+        log.info("생성한 UUID : {}", paymentOutBoxId);
+        // 유저 포인트 차감
+        this.paymentEventPublisher.publish(new KafkaMessage<>(
+                findPayment.getId(),
+                new PaymentEvent(command.userId(), findPayment.getId(), findPayment.getPaymentPrice(), paymentOutBoxId.toString())));
+
         // 예약 로그 생성
         //this.paymentLogRepository.save(new PaymentLog(null, null, findPayment.getId(), command.userId(), PaymentStatus.DONE.getValue()));
 
-        // event
-        //this.paymentEventPublisher.publish(new PaymentEvent(command.userId(), findPayment.getId(), findPayment.getPaymentPrice()));
-
         return findPayment;
+    }
+
+    public void outboxResend() {
+        List<PaymentOutbox> outboxList = paymentOutboxRepository.findOutboxByStatusAndCreateDate(PaymentOutboxStatus.INIT.getValue(), LocalDateTime.now().plusMinutes(5));
+
+        if(!outboxList.isEmpty()) {
+            outboxList.forEach(ob -> {
+                KafkaMessage<PaymentEvent> message = new KafkaMessage<>(ob.getPaymentId(), new PaymentEvent(ob.getUserId(), ob.getPaymentId(), ob.getPrice(), ob.getId()));
+                this.paymentEventPublisher.publish(message);
+            });
+        }
     }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/application/service/PointService.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/application/service/PointService.java
@@ -6,11 +6,13 @@ import com.example.hhpuls.concertReservation.common.exception.CustomException;
 import com.example.hhpuls.concertReservation.domain.domain.payment.UserPoint;
 import com.example.hhpuls.concertReservation.domain.error_code.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class PointService {
 
     private final UserPointRepository userPointRepository;
@@ -28,12 +30,13 @@ public class PointService {
 
     @Transactional
     public UserPoint usePoint(Long userId, Integer point) {
-        UserPoint userPoint = this.userPointRepository.findByIdWithOptimisticLock(userId).orElseThrow(
+        UserPoint userPoint = this.userPointRepository.find(userId).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_POINT_NOT_FOUND)
         );
+
         userPoint.use(point);
 
-        return userPointRepository.save(userPoint);
+        return userPoint;
     }
 
     public UserPoint getUserPoint(Long userId) {

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/PaymentOutbox.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/PaymentOutbox.java
@@ -1,0 +1,29 @@
+package com.example.hhpuls.concertReservation.domain.domain.payment;
+
+import com.example.hhpuls.concertReservation.domain.domain.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "payment_outbox")
+public class PaymentOutbox extends BaseTime {
+
+    @Id
+    private String id;
+
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    @Column(name = "outbox_status")
+    private Integer outboxStatus;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "price")
+    private Integer price;
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/consumer/PaymentConsumer.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/consumer/PaymentConsumer.java
@@ -1,12 +1,17 @@
 package com.example.hhpuls.concertReservation.domain.domain.payment.consumer;
 
+import com.example.hhpuls.concertReservation.application.repository.PaymentOutboxRepository;
 import com.example.hhpuls.concertReservation.application.service.PointService;
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashMap;
 
 @Component
 @RequiredArgsConstructor
@@ -14,15 +19,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentConsumer {
 
     private final PointService pointService;
+    private final ObjectMapper objectMapper;
+    private final PaymentOutboxRepository paymentOutboxRepository;
 
     @KafkaListener(topics = "payment-topic", groupId = "payment-group")
-    @Transactional
-    public void handleEvent(PaymentEvent paymentEvent) {
+    public void usePoint(KafkaMessage<?> message) {
         try {
+            LinkedHashMap<?, ?> map = (LinkedHashMap<?, ?>) message.getMessage();
+            PaymentEvent paymentEvent = objectMapper.convertValue(map, PaymentEvent.class);
             pointService.usePoint(paymentEvent.getUserId(), paymentEvent.getPrice());
         } catch (Exception e) {
-            log.error("꾸에에에에에에에에에에에에에에에엑");
             log.error(e.getMessage());
         }
+    }
+
+    @KafkaListener(topics = "payment-topic", groupId = "payment-group1")
+    public void completeOutbox(KafkaMessage<?> message) {
+        LinkedHashMap<?, ?> map = (LinkedHashMap<?, ?>) message.getMessage();
+        PaymentEvent paymentEvent = objectMapper.convertValue(map, PaymentEvent.class);
+        log.info("PUBLISH OutboxId: {}", paymentEvent.getOutBoxId());
+
+        this.paymentOutboxRepository.completeOutbox(paymentEvent.getOutBoxId());
     }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/consumer/PaymentConsumer.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/consumer/PaymentConsumer.java
@@ -1,0 +1,28 @@
+package com.example.hhpuls.concertReservation.domain.domain.payment.consumer;
+
+import com.example.hhpuls.concertReservation.application.service.PointService;
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentConsumer {
+
+    private final PointService pointService;
+
+    @KafkaListener(topics = "payment-topic", groupId = "payment-group")
+    @Transactional
+    public void handleEvent(PaymentEvent paymentEvent) {
+        try {
+            pointService.usePoint(paymentEvent.getUserId(), paymentEvent.getPrice());
+        } catch (Exception e) {
+            log.error("꾸에에에에에에에에에에에에에에에엑");
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/event/PaymentEvent.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/event/PaymentEvent.java
@@ -6,10 +6,13 @@ public class PaymentEvent {
     private Long paymentId;
     private Integer price;
 
-    public PaymentEvent(Long userId, Long paymentId, Integer price) {
+    private String outBoxId;
+
+    public PaymentEvent(Long userId, Long paymentId, Integer price, String outBoxId) {
         this.userId = userId;
         this.paymentId = paymentId;
         this.price = price;
+        this.outBoxId = outBoxId;
     }
 
     public PaymentEvent() {
@@ -28,4 +31,5 @@ public class PaymentEvent {
         return this.price;
     }
 
+    public String getOutBoxId() { return this.outBoxId; }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/event/PaymentEvent.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/event/PaymentEvent.java
@@ -1,15 +1,19 @@
 package com.example.hhpuls.concertReservation.domain.domain.payment.event;
 
 
-public class PaymentSuccessEvent {
+public class PaymentEvent {
     private Long userId;
     private Long paymentId;
     private Integer price;
 
-    public PaymentSuccessEvent(Long userId, Long paymentId, Integer price) {
+    public PaymentEvent(Long userId, Long paymentId, Integer price) {
         this.userId = userId;
         this.paymentId = paymentId;
         this.price = price;
+    }
+
+    public PaymentEvent() {
+
     }
 
     public Long getPaymentId() {

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/event/PaymentEventPublisher.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/event/PaymentEventPublisher.java
@@ -1,6 +1,8 @@
 package com.example.hhpuls.concertReservation.domain.domain.payment.event;
 
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
+
 public interface PaymentEventPublisher {
 
-    public void publish(PaymentSuccessEvent event);
+    public void publish(KafkaMessage<PaymentEvent> event);
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/message/PaymentMessageSender.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/message/PaymentMessageSender.java
@@ -1,9 +1,10 @@
 package com.example.hhpuls.concertReservation.domain.domain.payment.message;
 
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
 import org.springframework.stereotype.Component;
 
 @Component
 public interface PaymentMessageSender {
-    public void send(PaymentEvent event);
+    public void send(KafkaMessage<PaymentEvent> message);
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/message/PaymentMessageSender.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/domain/domain/payment/message/PaymentMessageSender.java
@@ -1,0 +1,9 @@
+package com.example.hhpuls.concertReservation.domain.domain.payment.message;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface PaymentMessageSender {
+    public void send(PaymentEvent event);
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/infrastructure/kafka/KafkaMessage.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/infrastructure/kafka/KafkaMessage.java
@@ -1,0 +1,25 @@
+package com.example.hhpuls.concertReservation.infrastructure.kafka;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KafkaMessage<T> {
+
+    private Long id;
+    private T message;
+
+    public KafkaMessage(Long id, T message) {
+        this.id = id;
+        this.message = message;
+    }
+
+    public KafkaMessage(PaymentEvent paymentEvent) {
+    }
+
+    public static <T> KafkaMessage<T> of(Long id, T message) {
+        return new KafkaMessage<>(id, message);
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/infrastructure/kafka/payment/PaymentKafkaMessageSender.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/infrastructure/kafka/payment/PaymentKafkaMessageSender.java
@@ -2,6 +2,7 @@ package com.example.hhpuls.concertReservation.infrastructure.kafka.payment;
 
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
 import com.example.hhpuls.concertReservation.domain.domain.payment.message.PaymentMessageSender;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,7 @@ public class PaymentKafkaMessageSender implements PaymentMessageSender {
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Override
-    public void send(PaymentEvent event) {
-        kafkaTemplate.send("payment-topic", event);
+    public void send(KafkaMessage<PaymentEvent> message) {
+        kafkaTemplate.send("payment-topic", message);
     }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/infrastructure/kafka/payment/PaymentKafkaMessageSender.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/infrastructure/kafka/payment/PaymentKafkaMessageSender.java
@@ -1,0 +1,19 @@
+package com.example.hhpuls.concertReservation.infrastructure.kafka.payment;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.domain.domain.payment.message.PaymentMessageSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentKafkaMessageSender implements PaymentMessageSender {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void send(PaymentEvent event) {
+        kafkaTemplate.send("payment-topic", event);
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/infrastructure/repository/impl/PaymentOutboxRepositoryImpl.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/infrastructure/repository/impl/PaymentOutboxRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.example.hhpuls.concertReservation.infrastructure.repository.impl;
+
+import com.example.hhpuls.concertReservation.application.repository.PaymentOutboxRepository;
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+import com.example.hhpuls.concertReservation.infrastructure.repository.jpa.JpaPaymentOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentOutboxRepositoryImpl implements PaymentOutboxRepository {
+
+    private final JpaPaymentOutboxRepository jpaPaymentOutboxRepository;
+
+    @Override
+    public Optional<PaymentOutbox> findById(String id) {
+        return this.jpaPaymentOutboxRepository.findById(id);
+    }
+
+    @Override
+    public PaymentOutbox save(PaymentOutbox paymentOutbox) {
+        return this.jpaPaymentOutboxRepository.save(paymentOutbox);
+    }
+
+    @Override
+    @Transactional
+    public void completeOutbox(String id) {
+       this.jpaPaymentOutboxRepository.updateStatus(id);
+    }
+
+    @Override
+    public List<PaymentOutbox> findOutboxByStatusAndCreateDate(Integer status, LocalDateTime nowPlusFiveMin) {
+        return this.jpaPaymentOutboxRepository.findAllByOutboxStatusAndCreateDate(status, nowPlusFiveMin);
+    }
+
+    @Override
+    public List<PaymentOutbox> findOutBoxByStatus(Integer status) {
+        return this.jpaPaymentOutboxRepository.findAllByOutboxStatus(status);
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/infrastructure/repository/jpa/JpaPaymentOutboxRepository.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/infrastructure/repository/jpa/JpaPaymentOutboxRepository.java
@@ -1,0 +1,22 @@
+package com.example.hhpuls.concertReservation.infrastructure.repository.jpa;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface JpaPaymentOutboxRepository extends JpaRepository<PaymentOutbox, String> {
+
+    @Modifying
+    @Query("UPDATE PaymentOutbox p SET p.outboxStatus = 1 WHERE p.id=:id")
+    void updateStatus(@Param("id") String id);
+
+    @Query("SELECT p FROM PaymentOutbox p WHERE p.outboxStatus =:status AND p.createDate > :nowPlusFiveMin")
+    List<PaymentOutbox> findAllByOutboxStatusAndCreateDate(Integer status, LocalDateTime nowPlusFiveMin);
+
+    List<PaymentOutbox> findAllByOutboxStatus(Integer outboxStatus);
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/config/KafkaConfig.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/config/KafkaConfig.java
@@ -1,6 +1,7 @@
 package com.example.hhpuls.concertReservation.interfaces.config;
 
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -9,7 +10,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
-public class KafkaProducerConfig {
+public class KafkaConfig {
 
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
@@ -31,14 +31,15 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public ConsumerFactory<String, PaymentEvent> consumerFactory() {
+    public ConsumerFactory<String, KafkaMessage<?>> consumerFactory() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         config.put(ConsumerConfig.GROUP_ID_CONFIG, "payment-group");
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        config.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
-        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), new JsonDeserializer<>(PaymentEvent.class));
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), new JsonDeserializer<>(KafkaMessage.class), false);
     }
 
     @Bean
@@ -48,8 +49,8 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, PaymentEvent> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, PaymentEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public ConcurrentKafkaListenerContainerFactory<String, KafkaMessage<?>> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, KafkaMessage<?>> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/config/KafkaProducerConfig.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/config/KafkaProducerConfig.java
@@ -1,0 +1,56 @@
+package com.example.hhpuls.concertReservation.interfaces.config;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        // Kafka Producer Factory 생성
+        Map<String, Object> producerConfig = new HashMap<>();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(producerConfig);
+    }
+
+    @Bean
+    public ConsumerFactory<String, PaymentEvent> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "payment-group");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), new JsonDeserializer<>(PaymentEvent.class));
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        // Kafka에 메세지를 보내기 위한 KafkaTemplate 생성
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, PaymentEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, PaymentEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentEventListener.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentEventListener.java
@@ -1,8 +1,7 @@
 package com.example.hhpuls.concertReservation.interfaces.event.listener;
 
 import com.example.hhpuls.concertReservation.application.service.SendService;
-import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEventPublisher;
-import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentSuccessEvent;
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -17,7 +16,7 @@ public class PaymentEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void paymentSuccessHandler(PaymentSuccessEvent event) throws InterruptedException {
+    public void paymentSuccessHandler(PaymentEvent event) throws InterruptedException {
         this.sendService.send(event.getPaymentId(), event.getUserId(), event.getPrice());
     }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentKafkaEventListener.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentKafkaEventListener.java
@@ -2,6 +2,7 @@ package com.example.hhpuls.concertReservation.interfaces.event.listener;
 
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
 import com.example.hhpuls.concertReservation.domain.domain.payment.message.PaymentMessageSender;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,7 @@ public class PaymentKafkaEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    void sendMessage(PaymentEvent paymentEvent) {
-        paymentMessageSender.send(paymentEvent);
+    void sendMessage(KafkaMessage<PaymentEvent> message) {
+        paymentMessageSender.send(message);
     }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentKafkaEventListener.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentKafkaEventListener.java
@@ -1,0 +1,22 @@
+package com.example.hhpuls.concertReservation.interfaces.event.listener;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.domain.domain.payment.message.PaymentMessageSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentKafkaEventListener {
+
+    private final PaymentMessageSender paymentMessageSender;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    void sendMessage(PaymentEvent paymentEvent) {
+        paymentMessageSender.send(paymentEvent);
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentOutboxListener.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/listener/PaymentOutboxListener.java
@@ -1,0 +1,20 @@
+package com.example.hhpuls.concertReservation.interfaces.event.listener;
+
+import com.example.hhpuls.concertReservation.application.repository.PaymentOutboxRepository;
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class PaymentOutboxListener {
+
+    private final PaymentOutboxRepository paymentOutboxRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void paymentOutboxEventHandler(PaymentOutbox paymentOutbox) {
+        this.paymentOutboxRepository.save(paymentOutbox);
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/publisher/PaymentEventPublisherImpl.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/publisher/PaymentEventPublisherImpl.java
@@ -1,7 +1,9 @@
 package com.example.hhpuls.concertReservation.interfaces.event.publisher;
 
 import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEventPublisher;
-import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentSuccessEvent;
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.domain.domain.payment.message.PaymentMessageSender;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -10,9 +12,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PaymentEventPublisherImpl implements PaymentEventPublisher {
 
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final PaymentMessageSender paymentMessageSender;
+
     @Override
-    public void publish(PaymentSuccessEvent event) {
-        this.applicationEventPublisher.publishEvent(event);
+    public void publish(KafkaMessage<PaymentEvent> event) {
+        this.paymentMessageSender.send(event);
     }
 }

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/publisher/PaymentOutboxEventPublisher.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/event/publisher/PaymentOutboxEventPublisher.java
@@ -1,0 +1,17 @@
+package com.example.hhpuls.concertReservation.interfaces.event.publisher;
+
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentOutboxEventPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void publish(PaymentOutbox paymentOutbox) {
+        this.applicationEventPublisher.publishEvent(paymentOutbox);
+    }
+}

--- a/src/main/java/com/example/hhpuls/concertReservation/interfaces/scheduler/PaymentOutboxScheduler.java
+++ b/src/main/java/com/example/hhpuls/concertReservation/interfaces/scheduler/PaymentOutboxScheduler.java
@@ -1,0 +1,20 @@
+package com.example.hhpuls.concertReservation.interfaces.scheduler;
+
+import com.example.hhpuls.concertReservation.application.service.PaymentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentOutboxScheduler {
+
+    private final PaymentService paymentService;
+
+    @Scheduled(fixedRate = 1, timeUnit = TimeUnit.MINUTES)
+    public void retryOutboxPublish() {
+        this.paymentService.outboxResend();
+    }
+}

--- a/src/main/resources/docker-compose.yml
+++ b/src/main/resources/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/src/test/java/com/example/hhpuls/concertReservation/integration/PaymentKafkaIntegrationTest.java
+++ b/src/test/java/com/example/hhpuls/concertReservation/integration/PaymentKafkaIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.example.hhpuls.concertReservation.integration;
+
+import com.example.hhpuls.concertReservation.application.repository.PaymentOutboxRepository;
+import com.example.hhpuls.concertReservation.application.repository.UserPointRepository;
+import com.example.hhpuls.concertReservation.common.enums.PaymentOutboxStatus;
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+import com.example.hhpuls.concertReservation.domain.domain.payment.UserPoint;
+import com.example.hhpuls.concertReservation.domain.domain.payment.consumer.PaymentConsumer;
+import com.example.hhpuls.concertReservation.domain.domain.payment.event.PaymentEvent;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.KafkaMessage;
+import com.example.hhpuls.concertReservation.infrastructure.kafka.payment.PaymentKafkaMessageSender;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, brokerProperties = { "listeners=PLAINTEXT://localhost:9092", "port=9092" })
+public class PaymentKafkaIntegrationTest {
+
+    @Autowired
+    PaymentKafkaMessageSender paymentKafkaMessageSender;
+
+    @Autowired
+    PaymentConsumer paymentConsumer;
+
+    @Autowired
+    UserPointRepository userPointRepository;
+
+    @Autowired
+    PaymentOutboxRepository paymentOutboxRepository;
+
+
+    @Test
+    void 카프카_메세지를_발행하면_컨슘하여_유저의_포인트를_차감한다() throws InterruptedException {
+        Long userId = 1L;
+        Long paymentId = 1L;
+        Integer price = 1000;
+        String outBoxId = UUID.randomUUID().toString();
+
+        UserPoint userPoint = userPointRepository.find(userId).orElseThrow(
+                () -> new IllegalArgumentException("유저 조회 실패"));
+
+
+        PaymentEvent paymentEvent = new PaymentEvent(userId, paymentId, price, outBoxId);
+        KafkaMessage<PaymentEvent> message = new KafkaMessage<>(paymentId, paymentEvent);
+
+        paymentKafkaMessageSender.send(message);
+
+        Thread.sleep(5000);
+
+        UserPoint updatedUserPoint = userPointRepository.find(userId).orElseThrow(
+                () -> new IllegalArgumentException("유저 조회 실패"));
+
+        // 유저의 금액이 차감되었는지 검증
+        Assertions.assertThat(userPoint.getPoint() - price).isEqualTo(updatedUserPoint.getPoint());
+    }
+
+    @Test
+    void 카프카_메세지를_발행하면_컨슘하여_Outbox_상태를_PUBLISHED로_업데이트한다() throws InterruptedException {
+        Long userId = 1L;
+        Long paymentId = 1L;
+        Integer price = 1000;
+        String outBoxId = UUID.randomUUID().toString();
+
+        PaymentEvent paymentEvent = new PaymentEvent(userId, paymentId, price, outBoxId);
+        KafkaMessage<PaymentEvent> message = new KafkaMessage<>(paymentId, paymentEvent);
+
+        paymentKafkaMessageSender.send(message);
+        Thread.sleep(5000);
+
+        PaymentOutbox paymentOutbox = paymentOutboxRepository.findById(outBoxId).orElseThrow(
+                () -> new IllegalArgumentException("OutBox 조회 실패")
+        );
+
+        Assertions.assertThat(paymentOutbox.getOutboxStatus()).isEqualTo(PaymentOutboxStatus.PUBLISHED.getValue());
+    }
+}

--- a/src/test/java/com/example/hhpuls/concertReservation/unit_test/scheduler/PaymentOutboxSchedulerTest.java
+++ b/src/test/java/com/example/hhpuls/concertReservation/unit_test/scheduler/PaymentOutboxSchedulerTest.java
@@ -1,0 +1,45 @@
+package com.example.hhpuls.concertReservation.unit_test.scheduler;
+
+import com.example.hhpuls.concertReservation.application.repository.PaymentOutboxRepository;
+import com.example.hhpuls.concertReservation.common.enums.PaymentOutboxStatus;
+import com.example.hhpuls.concertReservation.domain.domain.payment.PaymentOutbox;
+import com.example.hhpuls.concertReservation.interfaces.scheduler.PaymentOutboxScheduler;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@SpringBootTest
+public class PaymentOutboxSchedulerTest {
+
+    @Autowired
+    PaymentOutboxRepository paymentOutboxRepository;
+
+    @Autowired
+    PaymentOutboxScheduler paymentOutboxScheduler;
+
+    @Test
+    @DisplayName("INIT 상태인 Outbox 중 생성된 지 5분이상 된 데이터를 메시지 재전송하여 PUBLISHED 상태로 업데이트 한다.")
+    void 스케줄러_테스트() {
+        // given
+        int initOutboxNum = 3;
+        List<PaymentOutbox> paymentOutboxList = paymentOutboxRepository.findOutboxByStatusAndCreateDate(PaymentOutboxStatus.INIT.getValue(), LocalDateTime.now().plusMinutes(5));
+
+        // when
+        paymentOutboxScheduler.retryOutboxPublish();
+
+        // then
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Integer publishedOutboxNum = this.paymentOutboxRepository.findOutBoxByStatus(PaymentOutboxStatus.PUBLISHED.getValue()).size();
+                    Assertions.assertThat(publishedOutboxNum).isEqualTo(initOutboxNum);
+;                });
+    }
+}


### PR DESCRIPTION
STEP 17, STEP 18을 한 브랜치에서 작업하였습니다.


- 추후 User 서버가 분리될 것을 염두에 두고 결제 시 User의 잔액 차감을 카프카로 처리하였습니다.
- OutBox Pattern을 적용하여 이벤트 발행을 보장하였습니다.
- 스케줄러를 통해 미발행된 데이터에 대해 카프카 메세지를 재 전송하도록 구현하였습니다.